### PR TITLE
Fix node_modules name and inline code

### DIFF
--- a/node-intro/README.md
+++ b/node-intro/README.md
@@ -49,11 +49,11 @@ npm install express
   `.gitignore` in the top level of your repository that contains:
 
 ```
-node-modules
+node_modules
 ```
 
 This will prevent you from adding the node modules directory, which often contains many libraries,
-into your git repository. Instead, because you have a `package.json`, anyone can use ``npm install`
+into your git repository. Instead, because you have a `package.json`, anyone can use `npm install`
 to install all the dependencies for your project. To see how this works, you can always try cloning
 your repository to a new directory and do `npm install` there.
 


### PR DESCRIPTION
I noticed a couple of typos.  `node-modules` is actually spelled `node_modules`.  There was also a double backtick where there should have been a single backtick.